### PR TITLE
fix: add `@babel/runtime` as production dependency

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -15,14 +15,14 @@
     "build:report": "npm run build --report"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.2.5"
+    "@babel/polyfill": "^7.2.5",
+    "@babel/runtime": "^7.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.3",
-    "@babel/runtime": "^7.2.0",
     "autoprefixer": "^9.4.4",
     "awesome-ejs-compiled-loader": "^1.0.0",
     "babel-loader": "^8.0.5",


### PR DESCRIPTION
see https://babeljs.io/docs/en/babel-plugin-transform-runtime#installation