### PR TITLE
add the browserslistrc to support android 18 or above. 

### DIFF
--- a/template/.browserslistrc
+++ b/template/.browserslistrc
@@ -3,6 +3,7 @@ last 2 versions
 Firefox ESR
 not ie 10
 not ie_mob 10
+android >= 4.3
 
 [development]
 last 1 chrome version


### PR DESCRIPTION
add the browserslistrc to support android 18 or above. A common setting for mobile development.